### PR TITLE
docs: use initial-scale=1.0 in viewport meta for consistency

### DIFF
--- a/site/src/content/docs/getting-started/introduction.mdx
+++ b/site/src/content/docs/getting-started/introduction.mdx
@@ -37,7 +37,7 @@ Get started by including Bootstrap’s production-ready CSS and JavaScript via C
    <html lang="en">
      <head>
        <meta charset="utf-8">
-       <meta name="viewport" content="width=device-width, initial-scale=1">
+       <meta name="viewport" content="width=device-width, initial-scale=1.0">
        <title>Bootstrap demo</title>
        <link href="[[config:cdn.css]]" rel="stylesheet" integrity="[[config:cdn.css_hash]]" crossorigin="anonymous">
      </head>


### PR DESCRIPTION
This PR updates the viewport meta tag 
example in introduction.mdx to use 
"initial-scale=1.0" instead of "initial-scale=1".
Although both value work in HTML
using "1.0" improves clarity and keeps consistency with other Bootstrap documentation and examples.

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
